### PR TITLE
Replacing execSync dependency with shelljs

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -2,7 +2,7 @@
 var glob = require('glob');
 var path = require('path');
 var fs = require('fs-extra');
-var sh = require('execSync');
+var sh = require('shelljs');
 var util = require('util');
 var chokidar = require('chokidar');
 // framework
@@ -25,7 +25,7 @@ var framework = function (emitter, config, logger) {
     var pluginIndex = 0;
     var spliceCount = 0;
     config.optimizer.plugins.forEach(function (plugin, index) {
-        if(plugin === 'optimizer-require' || plugin.plugin === 'optimizer-require') {
+        if (plugin === 'optimizer-require' || plugin.plugin === 'optimizer-require') {
             requirePlugin = plugin;
             pluginIndex = index;
             spliceCount = 1;
@@ -41,14 +41,14 @@ var framework = function (emitter, config, logger) {
     }
     // add or update the optimizer-require configuration
     config.optimizer.plugins.splice(pluginIndex, spliceCount, requirePlugin);
-    // normalize the files param to an array 
+    // normalize the files param to an array
     if (!util.isArray(config.files)) {
         config.files = [
             config.files
         ];
     }
     var filesArray = [];
-    // `config.files` will have a list of glob patterns. we convert it into a list of files 
+    // `config.files` will have a list of glob patterns. we convert it into a list of files
     config.files.map(function (oneConfig) {
         return oneConfig.pattern;
     }).map(function (pattern) {
@@ -98,8 +98,13 @@ var framework = function (emitter, config, logger) {
         watchPath
     ].join(' ');
     log.debug('running command: ' + command);
-    // FIXME: check for command errors
-    sh.run(command);
+
+    var returnedObject = sh.exec(command);
+    if (returnedObject.code !== 0) {
+        log.error(returnedObject.output);
+        exit(1);
+    }
+
     // clear the config.files array and push the newly created files into the array
     log.debug(config.files);
     config.files.forEach(function (oneFile) {
@@ -120,11 +125,15 @@ var framework = function (emitter, config, logger) {
         var watchedFiles = fs.readJsonSync(watchPath);
         var watcher = chokidar.watch(watchedFiles.shift());
         watcher.add(watchedFiles);
-        watcher.on('change', function(path) {
+        watcher.on('change', function (path) {
             console.log('File', path, 'has changed');
             log.debug('running command: ' + command);
-            // FIXME: check for command errors
-            sh.run(command);
+
+            var returnedObject = sh.exec(command);
+            if (returnedObject.code !== 0) {
+                log.error(returnedObject.output);
+                exit(1);
+            }
         });
     }
 };

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -102,7 +102,7 @@ var framework = function (emitter, config, logger) {
     var returnedObject = sh.exec(command);
     if (returnedObject.code !== 0) {
         log.error(returnedObject.output);
-        exit(1);
+        sh.exit(1);
     }
 
     // clear the config.files array and push the newly created files into the array
@@ -132,7 +132,7 @@ var framework = function (emitter, config, logger) {
             var returnedObject = sh.exec(command);
             if (returnedObject.code !== 0) {
                 log.error(returnedObject.output);
-                exit(1);
+                sh.exit(1);
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,40 +1,38 @@
 {
-    "name": "karma-optimizer",
-    "version": "0.0.8",
-    "description": "karma plugin for raptorjs optimizer",
-    "main": "lib",
-    "scripts": {
-        "test": "grunt test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/pranavjha/karma-optimizer.git"
-    },
-
-    "dependencies": {
-        "execSync": "^1",
-        "fs-extra": "^0",
-        "glob": "^4",
-        "istanbul": "^0",
-        "through": "^2",
-        "minimatch": "^2",
-        "chokidar": "^1.0.0-rc3"
-    },
-    "peerDependencies": {
-        "optimizer": "^1",
-        "optimizer-require": "^1"
-    },
-    "devDependencies": {
-        "grunt": "^0",
-        "grunt-contrib-jshint": "^0",
-        "grunt-docco": "^0",
-        "grunt-gh-pages": "^0"
-    },
-    "keywords": [
-        "karma",
-        "raptorjs",
-        "optimizer"
-    ],
-    "author": "Pranav Jha <jha.pranav.s@gmail.com> (https://github.com/pranavjha)",
-    "license": "MIT"
+  "name": "karma-lasso",
+  "version": "0.0.8",
+  "description": "karma plugin for lasso",
+  "main": "lib",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pranavjha/karma-lasso.git"
+  },
+  "dependencies": {
+    "chokidar": "^1.0.0-rc3",
+    "fs-extra": "^0",
+    "glob": "^4",
+    "istanbul": "^0",
+    "minimatch": "^2",
+    "shelljs": "^0.4.0",
+    "through": "^2"
+  },
+  "peerDependencies": {
+    "optimizer": "^1",
+    "optimizer-require": "^1"
+  },
+  "devDependencies": {
+    "grunt": "^0",
+    "grunt-contrib-jshint": "^0",
+    "grunt-docco": "^0",
+    "grunt-gh-pages": "^0"
+  },
+  "keywords": [
+    "karma",
+    "lasso"
+  ],
+  "author": "Pranav Jha <jha.pranav.s@gmail.com> (https://github.com/pranavjha)",
+  "license": "MIT"
 }


### PR DESCRIPTION
By replacing execSync with shelljs I made the karma-lasso plugin working on mac osx.
[shelljs](https://www.npmjs.com/package/shelljs) -  seems to be much better option. It has much wider adoption and seems to be more mature thatn execSync.