### PR TITLE
Fixing bug that was causing karma --watch to fail. 

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -149,7 +149,7 @@ var framework = function(emitter, config, logger) {
             log.debug('File', path, 'has changed');
             log.debug('running command: ' + command);
             // FIXME: check for command errors
-            sh.run(command);
+            sh.exec(command);
         });
     }
 };


### PR DESCRIPTION
shelljs doesn't have run command in the api, so I replaced it with sh.exec.

@pranavjha please review.