### PR TITLE
testing for undefined coverage

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -6,12 +6,14 @@ var path = require('path');
 // takes the absolute file path which doesnt look good on coverage reports
 var makeRelative = function(coverage) {
     var normalizedCoverage = {};
-    Object.keys(coverage).forEach(function(filePath) {
-        var val = coverage[filePath];
-        var relativePath = path.relative(process.cwd(), filePath).replace(/\\/g, '/');
-        val.path = relativePath;
-        normalizedCoverage[relativePath] = val;
-    });
+    if(coverage) {
+        Object.keys(coverage).forEach(function(filePath) {
+            var val = coverage[filePath];
+            var relativePath = path.relative(process.cwd(), filePath).replace(/\\/g, '/');
+            val.path = relativePath;
+            normalizedCoverage[relativePath] = val;
+        });
+    }
     return normalizedCoverage;
 };
 // Reporter type
@@ -19,9 +21,7 @@ var Reporter = function(config, helper, logger) {
     var log = logger.create('reporter:lasso');
     this.onBrowserComplete = function(browser, result) {
         var collector = new istanbul.Collector();
-        if(result.coverage) {
-            collector.add(makeRelative(result.coverage));
-        }
+        collector.add(makeRelative(result.coverage));
         // normalize the reporters into an array
         log.debug('dumping coverage report(s) for ' + browser.name);
         if (!util.isArray(config.lasso.coverage.reporters)) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -19,7 +19,9 @@ var Reporter = function(config, helper, logger) {
     var log = logger.create('reporter:lasso');
     this.onBrowserComplete = function(browser, result) {
         var collector = new istanbul.Collector();
-        collector.add(makeRelative(result.coverage));
+        if(result.coverage) {
+            collector.add(makeRelative(result.coverage));
+        }
         // normalize the reporters into an array
         log.debug('dumping coverage report(s) for ' + browser.name);
         if (!util.isArray(config.lasso.coverage.reporters)) {


### PR DESCRIPTION
I ran into an issue where no coverage files were identified. This threw an unhandled error that caused the process to freeze. This fix adds a null check which doesn't appear to have any side effects, from my testing.