### PR TITLE
Update lasso-require dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "peerDependencies": {
         "lasso": "^2",
-        "lasso-require": "^1"
+        "lasso-require": ">=1"
     },
     "devDependencies": {
         "grunt": "^0",


### PR DESCRIPTION
Lasso-require is now on version 3.1.3, which includes changes that are required by the eBay homepage team.  However, karma-lasso sets lasso-require's version at `^1`, giving us peer dependency errors. This proposes to change lasso-require's version to `>=1` instead.

cc @patrick-steele-idem