### PR TITLE
adding require-self-ref

### DIFF
--- a/lib/helpers/lasso-command.js
+++ b/lib/helpers/lasso-command.js
@@ -2,12 +2,11 @@
 if (process.argv[6]) {
     process.argv[6].split(',').forEach(function(path) {
         if (path) {
-            try {
+            if(require.resolve('app-module-path')) {
+                require('app-module-path').addPath(path);
+            } else if(require.resolve('require-self-ref')) {
                 require('require-self-ref');
-            } catch(e) {
-                console.warn('Module `require-self-ref` not found.. ' + e.message);
             }
-            require('app-module-path').addPath(path);
         }
     });
 }

--- a/lib/helpers/lasso-command.js
+++ b/lib/helpers/lasso-command.js
@@ -2,6 +2,11 @@
 if (process.argv[6]) {
     process.argv[6].split(',').forEach(function(path) {
         if (path) {
+            try {
+                require('require-self-ref');
+            } catch(e) {
+                console.warn('Module `require-self-ref` not found.. ' + e.message);
+            }
             require('app-module-path').addPath(path);
         }
     });


### PR DESCRIPTION
Mostly both `require-self-ref` and `app-module-path` will have to co-exist for a while before the later is phased out. Not every project would have `require-self-ref`, so wrapping it in a `try.. catch`.