### PR TITLE
Updated unshift to push  for coverage

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -30,7 +30,7 @@ var framework = function(emitter, config, logger) {
     }
     // include the instrumentation transform if the coverage is to be done
     if (config.lasso.coverage) {
-        config.lasso.require.transforms.unshift('karma-lasso/lib/transforms/coverage');
+        config.lasso.require.transforms.push('karma-lasso/lib/transforms/coverage');
     }
     // normalize the files param to an array
     if (!util.isArray(config.files)) {


### PR DESCRIPTION
With lasso 3, we see an issue  when you run karma coverage while using babel. The coverage code executes before the transform.

Updating to push makes sure the transforms are always run before coverage.

I made the same change with lasso-2 and it did not break coverage.  This can be a minor version