### PR TITLE
Use istanbul-lib-instrument instead of istanbul to instrument code coverage

### DIFF
--- a/lib/transforms/coverage.js
+++ b/lib/transforms/coverage.js
@@ -1,5 +1,5 @@
 'use strict';
-var istanbul = require('istanbul');
+var istanbul = require('istanbul-lib-instrument');
 var through = require('through');
 var minimatch = require('minimatch');
 var fs = require('fs-extra');
@@ -31,7 +31,7 @@ module.exports = function(name) {
         }
 
         // instrument the non ignored files
-        var instrumenter = new istanbul.Instrumenter(coverageConfig.instrumenterConfig || {});
+        var instrumenter = istanbul.createInstrumenter(coverageConfig.instrumenterConfig || {});
         var data = '';
         return through(function(buf) {
             data += buf;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,271 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+            "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+            "requires": {
+                "@babel/highlight": "^7.14.5"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
+            "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw=="
+        },
+        "@babel/core": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.8.tgz",
+            "integrity": "sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==",
+            "requires": {
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.14.8",
+                "@babel/helper-compilation-targets": "^7.14.5",
+                "@babel/helper-module-transforms": "^7.14.8",
+                "@babel/helpers": "^7.14.8",
+                "@babel/parser": "^7.14.8",
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.8",
+                "@babel/types": "^7.14.8",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
+            "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
+            "requires": {
+                "@babel/types": "^7.14.9",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+            "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+            "requires": {
+                "@babel/compat-data": "^7.14.5",
+                "@babel/helper-validator-option": "^7.14.5",
+                "browserslist": "^4.16.6",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+            "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.14.5",
+                "@babel/template": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+            "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+            "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+            "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+            "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
+            "integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.14.5",
+                "@babel/helper-replace-supers": "^7.14.5",
+                "@babel/helper-simple-access": "^7.14.8",
+                "@babel/helper-split-export-declaration": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.14.8",
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.8",
+                "@babel/types": "^7.14.8"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+            "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+            "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.14.5",
+                "@babel/helper-optimise-call-expression": "^7.14.5",
+                "@babel/traverse": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+            "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+            "requires": {
+                "@babel/types": "^7.14.8"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+            "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+            "requires": {
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+            "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+        },
+        "@babel/helpers": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+            "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+            "requires": {
+                "@babel/template": "^7.14.5",
+                "@babel/traverse": "^7.14.8",
+                "@babel/types": "^7.14.8"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.5",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
+            "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ=="
+        },
+        "@babel/template": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+            "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+            "requires": {
+                "@babel/code-frame": "^7.14.5",
+                "@babel/parser": "^7.14.5",
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
+            "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+            "requires": {
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.14.9",
+                "@babel/helper-function-name": "^7.14.5",
+                "@babel/helper-hoist-variables": "^7.14.5",
+                "@babel/helper-split-export-declaration": "^7.14.5",
+                "@babel/parser": "^7.14.9",
+                "@babel/types": "^7.14.9",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+            "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.9",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="
+        },
         "abbrev": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -25,7 +290,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -197,6 +461,18 @@
                 "repeat-element": "^1.1.2"
             }
         },
+        "browserslist": {
+            "version": "4.16.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+            "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+            "requires": {
+                "caniuse-lite": "^1.0.30001248",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.793",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.73"
+            }
+        },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -236,11 +512,15 @@
                 "map-obj": "^1.0.0"
             }
         },
+        "caniuse-lite": {
+            "version": "1.0.30001248",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
+            "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -250,14 +530,12 @@
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
                 },
                 "supports-color": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -357,7 +635,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -365,8 +642,12 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
         },
         "colors": {
             "version": "1.1.2",
@@ -396,6 +677,14 @@
             "dev": true,
             "requires": {
                 "date-now": "^0.1.4"
+            }
+        },
+        "convert-source-map": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+            "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+            "requires": {
+                "safe-buffer": "~5.1.1"
             }
         },
         "copy-descriptor": {
@@ -587,6 +876,11 @@
                 "domelementtype": "1"
             }
         },
+        "electron-to-chromium": {
+            "version": "1.3.794",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.794.tgz",
+            "integrity": "sha512-lN6h2N16+B64/DDNefd2qvehTJl/LDZ/ORXKL2JHaLGhVxjj7ybuA/oVprKtTNvmOTgzUrpP02HhgoS27E2rGA=="
+        },
         "entities": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -602,6 +896,11 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -611,8 +910,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
             "version": "1.8.1",
@@ -1282,6 +1580,11 @@
                 }
             }
         },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+        },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -1328,6 +1631,11 @@
             "requires": {
                 "is-glob": "^2.0.0"
             }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "graceful-fs": {
             "version": "4.2.2",
@@ -1897,11 +2205,39 @@
                 }
             }
         },
+        "istanbul-lib-coverage": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+            "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
+        },
+        "istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "jquery": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
             "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI=",
             "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -1918,6 +2254,11 @@
                     "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
                 }
             }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "jshint": {
             "version": "2.9.7",
@@ -1940,6 +2281,21 @@
                     "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
                     "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
                     "dev": true
+                }
+            }
+        },
+        "json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "requires": {
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
                 }
             }
         },
@@ -2205,6 +2561,11 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
             "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
+        "node-releases": {
+            "version": "1.1.73",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
         },
         "nopt": {
             "version": "3.0.6",
@@ -3275,6 +3636,11 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         },
         "to-object-path": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
         "url": "https://github.com/lasso-js/karma-lasso.git"
     },
     "dependencies": {
-        "shelljs": "0.5.3",
+        "chokidar": "^1",
         "fs-extra": "^0",
         "istanbul": "^0",
-        "through": "^2",
+        "istanbul-lib-instrument": "^4.0.3",
         "minimatch": "^3",
-        "chokidar": "^1"
+        "shelljs": "0.5.3",
+        "through": "^2"
     },
     "peerDependencies": {
         "lasso": ">=3"


### PR DESCRIPTION
## Description

Current coverage.js uses istanbul 0.4.5 to transform code coverage. The report format is incompatible with nyc command which uses istanbul-lib-instrument v4.

This PR updates the code to use istanbul-lib-instrument latest version.